### PR TITLE
Allow to use this module with enabled logging

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -50,6 +50,13 @@ resource "yandex_resourcemanager_folder_iam_member" "sa_public_loadbalancers_rol
   member    = "serviceAccount:${yandex_iam_service_account.master.id}"
 }
 
+resource "yandex_resourcemanager_folder_iam_member" "sa_logging_writer_role" {
+  count     = var.master_logging.enabled ? 1 : 0
+  folder_id = local.folder_id
+  role      = "logging.writer"
+  member    = "serviceAccount:${yandex_iam_service_account.master.id}"
+}
+
 resource "yandex_resourcemanager_folder_iam_member" "node_account" {
   folder_id = local.folder_id
   role      = "container-registry.images.puller"

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,7 @@ resource "yandex_kubernetes_cluster" "kube_cluster" {
     yandex_resourcemanager_folder_iam_member.sa_cilium_network_policy_role,
     yandex_resourcemanager_folder_iam_member.sa_node_group_public_role_admin,
     yandex_resourcemanager_folder_iam_member.sa_node_group_loadbalancer_role_admin,
+    yandex_resourcemanager_folder_iam_member.sa_logging_writer_role,
     yandex_resourcemanager_folder_iam_member.sa_public_loadbalancers_role
   ]
 


### PR DESCRIPTION
Without extra role cluster creation will fail with following error: master serviceAccount permission for Cluster: master logging require 'logging.writer' role to be assigned to master serviceAccount