### PR TITLE
Set 1.22 node_groups in example

### DIFF
--- a/examples/example-3-zonal-regional-clusters-with-custom-rules/main.tf
+++ b/examples/example-3-zonal-regional-clusters-with-custom-rules/main.tf
@@ -41,7 +41,7 @@ module "kube_01" {
       }
     },
     "yc-k8s-ng-02" = {
-      version     = "1.21"
+      version     = "1.22"
       description = "Kubernetes nodes group 02"
       auto_scale = {
         min     = 3


### PR DESCRIPTION
Fix error:
```
│ requested version can't be used to create node-group for Node Group: Requested version '1.21', master current version '1.23'.
│ Available versions: ['1.22', '1.23']
```