### PR TITLE
Add the missing metadata property for cluster nodes

### DIFF
--- a/node_group.tf
+++ b/node_group.tf
@@ -89,6 +89,7 @@ resource "yandex_kubernetes_node_group" "kube_node_groups" {
         type = container_runtime.value
       }
     }
+    metadata = try(each.value.metadata, null)
   }
 
   node_labels            = try(each.value.node_labels, null)


### PR DESCRIPTION
This is a fix of missing ability to get ssh access to nodes