### PR TITLE
add egress rule for k8s_main_sg security group

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -43,6 +43,14 @@ resource "yandex_vpc_security_group" "k8s_main_sg" {
     from_port         = 0
     to_port           = 65535
   }
+
+  egress {
+    protocol       = "ANY"
+    description    = "Rule allows pod-pod and service-service communication inside a security group. Indicate your IP ranges."
+    v4_cidr_blocks = [var.cluster_ipv4_range, var.service_ipv4_range]
+    from_port      = 0
+    to_port        = 65535
+  }
 }
 
 resource "yandex_vpc_security_group" "k8s_master_whitelist_sg" {


### PR DESCRIPTION
Add egress rule to allow validation webhook requests from master-nodes to worker-nodes

```
│       * Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://ingress-nginx-controller-admission.ingress.svc:443/networking/v1/ingresses?timeout=10s": dial tcp 172.18.188.220:443: connect: connection timed out
│       * Internal error occurred: failed calling webhook "validate.externalsecret.external-secrets.io": failed to call webhook: Post "https://external-secrets-webhook.external-secrets.svc:443/validate-external-secrets-io-v1beta1-externalsecret?timeout=5s": context deadline exceeded
```