### PR TITLE
Adding security group ID to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -106,3 +106,11 @@ output "service_account_id" {
   EOF
   value       = try(yandex_iam_service_account.master[0].id, "")
 }
+
+# Nodes security group id
+output "nodes_security_group_ids" {
+  description = <<EOF
+    Security groups IDs created for nodes in Kubernetes cluster.
+  EOF
+  value       = local.node_group_security_groups_list
+}


### PR DESCRIPTION
When using this module alongside a separately managed `yandex_kubernetes_node_group` resource, I encountered an issue: the security group ID created within the module is not available in the outputs, making it impossible to pass this ID to the separate resource.

This PR adds the security group ID to the module outputs to resolve this issue.