### PR TITLE
feat: separate cluster and node group labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ module "kube" {
   source     = "./modules/kubernetes"
   network_id = "enpmff6ah2bvi0k10j66"
 
+  # Cluster labels - applied to the Kubernetes cluster resource
+  labels = {
+    project     = "my-project"
+    environment = "production"
+    owner       = "platform-team"
+    managed-by  = "terraform"
+  }
+
   master_locations   = [
     {
       zone      = "ru-central1-a"
@@ -88,6 +96,12 @@ module "kube" {
       fixed_scale   = {
         size = 3
       }
+      # Node group specific labels - applied to the node group resource
+      labels = {
+        node-pool = "compute-optimized"
+        workload  = "web-servers"
+      }
+      # Kubernetes node labels - applied to compute VMs
       node_labels   = {
         role        = "worker-01"
         environment = "testing"
@@ -106,6 +120,12 @@ module "kube" {
           subnet_id = "e2lu07tr481h35012c8p"
         }
       ]
+      # Node group specific labels - applied to the node group resource
+      labels = {
+        node-pool = "auto-scaling"
+        workload  = "api-servers"
+      }
+      # Kubernetes node labels - applied to compute VMs
       node_labels   = {
         role        = "worker-02"
         environment = "dev"
@@ -206,8 +226,9 @@ No modules.
 | <a name="input_enable_outgoing_traffic"></a> [enable\_outgoing\_traffic](#input\_enable\_outgoing\_traffic) | Enables all outgoing traffic. Nodes can connect to Yandex Container Registry, Yandex Object Storage, Docker Hub, and so on..<br/><br/>"rule-1" = {<br/>  protocol       = "ANY"<br/>  description    = "Rule allows all outgoing traffic. Nodes can connect to Yandex Container Registry, Yandex Object Storage, Docker Hub, and so on."<br/>  v4\_cidr\_blocks = ["0.0.0.0/0"]<br/>  from\_port      = 0<br/>  to\_port        = 65535<br/>} | `bool` | `true` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The ID of the folder that the Kubernetes cluster belongs to. | `string` | `null` | no |
 | <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | KMS symmetric key parameters. | `any` | `{}` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of key/value label pairs to assign to the Kubernetes cluster. | `map(string)` | `{}` | no |
 | <a name="input_master_auto_upgrade"></a> [master\_auto\_upgrade](#input\_master\_auto\_upgrade) | Boolean flag that specifies if master can be upgraded automatically. | `bool` | `true` | no |
-| <a name="input_master_labels"></a> [master\_labels](#input\_master\_labels) | Set of key/value label pairs to assign Kubernetes master nodes. | `map(string)` | `{}` | no |
+| <a name="input_master_labels"></a> [master\_labels](#input\_master\_labels) | Set of key/value label pairs to assign Kubernetes master nodes (deprecated, use 'labels' variable instead) | `map(string)` | `{}` | no |
 | <a name="input_master_locations"></a> [master\_locations](#input\_master\_locations) | List of locations where the cluster will be created. If the list contains only one<br/>location, a zonal cluster will be created; if there are three locations, this will create a regional cluster.<br/><br/>Note: The master locations list may only have ONE or THREE locations. | <pre>list(object({<br/>    zone      = string<br/>    subnet_id = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_master_logging"></a> [master\_logging](#input\_master\_logging) | (Optional) Master logging options. | <pre>object({<br/>    enabled                = optional(bool, true)<br/>    folder_id              = optional(string, null)<br/>    enabled_kube_apiserver = optional(bool, true)<br/>    enabled_autoscaler     = optional(bool, true)<br/>    enabled_events         = optional(bool, true)<br/>    enabled_audit          = optional(bool, true)<br/>    log_group_id           = optional(string, null)<br/>  })</pre> | `{}` | no |
 | <a name="input_master_maintenance_windows"></a> [master\_maintenance\_windows](#input\_master\_maintenance\_windows) | List of structures that specifies maintenance windows,<br/>    when auto update for the master is allowed.<br/><br/>    Example:<pre>master_maintenance_windows = [<br/>      {<br/>        day        = "monday"<br/>        start_time = "23:00"<br/>        duration   = "3h"<br/>      }<br/>    ]</pre> | `list(map(string))` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ module "kube" {
         workload  = "web-servers"
       }
       # Kubernetes node labels - applied to compute VMs
-      node_labels   = {
+      instance_labels   = {
         role        = "worker-01"
         environment = "testing"
       }
@@ -126,7 +126,7 @@ module "kube" {
         workload  = "api-servers"
       }
       # Kubernetes node labels - applied to compute VMs
-      node_labels   = {
+      instance_labels   = {
         role        = "worker-02"
         environment = "dev"
       }

--- a/examples/example-2-regional-with-7-various-ng/main.tf
+++ b/examples/example-2-regional-with-7-various-ng/main.tf
@@ -3,6 +3,14 @@ module "kube" {
 
   network_id = "enp9rm1debn7usfmtlnv"
 
+  # Cluster labels - applied to the Kubernetes cluster resource
+  labels = {
+    project     = "example-project"
+    environment = "testing"
+    owner       = "example-team"
+    managed-by  = "terraform"
+  }
+
   master_locations = [
     {
       zone      = "ru-central1-a"

--- a/examples/example-2-regional-with-7-various-ng/main.tf
+++ b/examples/example-2-regional-with-7-various-ng/main.tf
@@ -38,7 +38,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-01"
         environment = "testing"
       }
@@ -54,7 +54,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-02"
         environment = "testing"
       }
@@ -70,7 +70,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-03"
         environment = "testing"
       }
@@ -92,7 +92,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-04"
         environment = "testing"
       }
@@ -108,7 +108,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-05"
         environment = "testing"
       }
@@ -130,7 +130,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-06"
         environment = "testing"
       }
@@ -144,7 +144,7 @@ module "kube" {
         owner   = "example"
         service = "kubernetes"
       }
-      node_labels = {
+      instance_labels = {
         role        = "worker-07"
         environment = "testing"
       }

--- a/main.tf
+++ b/main.tf
@@ -11,14 +11,8 @@ locals {
     yandex_vpc_security_group.k8s_master_whitelist_sg[0].id
   ] : [])
 
-  # Merging master labels with node group labels
-  node_groups_labels = concat([
-    for i, v in tolist(keys(var.node_groups)) : lookup(var.node_groups[v], "labels", {})
-  ])
-  merged_node_labels_with_master = merge(zipmap(
-    flatten([for item in local.node_groups_labels : keys(item)]),
-    flatten([for item in local.node_groups_labels : values(item)])
-  ), var.master_labels)
+  # Cluster labels logic with backward compatibility
+  cluster_labels = length(var.labels) > 0 ? var.labels : var.master_labels
 }
 
 resource "time_sleep" "wait_for_iam" {
@@ -34,12 +28,27 @@ resource "time_sleep" "wait_for_iam" {
   ]
 }
 
+# Validation and deprecation warning
+check "labels_validation" {
+  assert {
+    condition     = !(length(var.master_labels) > 0 && length(var.labels) > 0)
+    error_message = "Cannot use both 'labels' and 'master_labels' variables simultaneously. Please use 'labels' variable for cluster labels."
+  }
+}
+
+check "master_labels_deprecation" {
+  assert {
+    condition     = length(var.master_labels) == 0
+    error_message = "WARNING: The 'master_labels' variable is deprecated and will be removed in a future version. Please use the 'labels' variable instead for cluster labels."
+  }
+}
+
 resource "yandex_kubernetes_cluster" "kube_cluster" {
   name                     = "${var.cluster_name}-${random_string.unique_id.result}"
   description              = var.description
   folder_id                = local.folder_id
   network_id               = var.network_id
-  labels                   = try(local.merged_node_labels_with_master, {})
+  labels                   = local.cluster_labels
   cluster_ipv4_range       = var.cluster_ipv4_range
   cluster_ipv6_range       = var.cluster_ipv6_range
   node_ipv4_cidr_mask_size = var.node_ipv4_cidr_mask_size

--- a/variables.tf
+++ b/variables.tf
@@ -223,8 +223,14 @@ variable "master_logging" {
   default = {}
 }
 
+variable "labels" {
+  description = "Set of key/value label pairs to assign to the Kubernetes cluster."
+  type        = map(string)
+  default     = {}
+}
+
 variable "master_labels" {
-  description = "Set of key/value label pairs to assign Kubernetes master nodes."
+  description = "Set of key/value label pairs to assign Kubernetes master nodes (deprecated, use 'labels' variable instead)"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
Add new labels variable for cluster-specific labels Deprecate master_labels variable with validation warnings Remove automatic merging of node group labels into cluster labels Update logic to use labels with fallback to master_labels Add validation checks to prevent simultaneous use of both variables Update documentation and examples to demonstrate new approach Maintain backward compatibility for existing configurations

BREAKING CHANGE: Cluster labels no longer automatically include node group labels. Use the new labels variable for cluster-level labels and keep node group labels separate.