### PR TITLE
KMS: add deletion protection option

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -4,12 +4,13 @@ locals {
 }
 
 resource "yandex_kms_symmetric_key" "kms_key" {
-  count             = var.create_kms ? 1 : 0
-  folder_id         = local.folder_id
-  name              = local.kms_key_with_id
-  description       = lookup(var.kms_key, "description", "K8S KMS symmetric key")
-  default_algorithm = lookup(var.kms_key, "default_algorithm", "AES_256")
-  rotation_period   = lookup(var.kms_key, "rotation_period", "8760h")
+  count               = var.create_kms ? 1 : 0
+  folder_id           = local.folder_id
+  name                = local.kms_key_with_id
+  description         = lookup(var.kms_key, "description", "K8S KMS symmetric key")
+  default_algorithm   = lookup(var.kms_key, "default_algorithm", "AES_256")
+  rotation_period     = lookup(var.kms_key, "rotation_period", "8760h")
+  deletion_protection = lookup(var.kms_key, "deletion_protection", false)
 }
 
 resource "yandex_kms_symmetric_key_iam_binding" "encrypter_decrypter" {


### PR DESCRIPTION
**Motivation:**
In production environments it can be critical to set deletion protection for keys in KMS.

**Issue:**
In current module version there is no possibility to choose deletion protection for KMS key.
The default is `false`.

**Change:**
Add the possibility to set `deletion_protection` parameter in `kms_key` variable of the module.
The behavior of the module will not change, as `false` value for this parameter is kept by default.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru